### PR TITLE
C

### DIFF
--- a/add_A11
+++ b/add_A11
@@ -1,0 +1,1 @@
+qsfdqsfqsf

--- a/add_in_a.txt
+++ b/add_in_a.txt
@@ -1,1 +1,1 @@
-sqfdqsdf
+sqfdqsdfesfsef

--- a/add_in_a.txt
+++ b/add_in_a.txt
@@ -1,0 +1,1 @@
+sqfdqsdf

--- a/commit.template
+++ b/commit.template
@@ -1,0 +1,13 @@
+{{ title }}
+
+{{ body | get_section("## Description", "") }}
+
+Pull-Request: #{{ number }}.
+{# Here comes some fancy Jinja2 stuff for correctly attributing co-authorship: #}
+{% for commit in (commits | unique(False, 'email_author')) | rejectattr("author", "==", author) %}
+{% if commit.parents|length == 1 %}
+Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
+    {% endif %}
+    {% endfor %}
+    {# GitHub requires that the `Co-authored-by` lines are AT THE VERY END of a commit, hence nothing must come after
+    this. #}


### PR DESCRIPTION
{{ body | get_section("## Description", "") }}

Pull-Request: #{{ number }}.
{# Here comes some fancy Jinja2 stuff for correctly attributing co-authorship: #}
{% for commit in (commits | unique(False, 'email_author')) | rejectattr("author", "==", author) %}
{% if commit.parents|length == 1 %}
Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
    {% endif %}
    {% endfor %}
    {# GitHub requires that the `Co-authored-by` lines are AT THE VERY END of a commit, hence nothing must come after
    this. #}